### PR TITLE
Handling redeem response error message.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evernode-js-client",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "scripts": {
         "build": "ncc build src/index.js -e eccrypto -e ripple-lib -o dist/",
         "bundle": "npm run build && ./clean-pkg.sh",

--- a/src/evernode-client.js
+++ b/src/evernode-client.js
@@ -94,7 +94,7 @@ class EvernodeClient {
                         const payload = data.Memos[1].data;
                         if (data.Memos[1].format === MemoFormats.JSON) { // Format text/json means this is an error message. 
                             const data = JSON.parse(payload);
-                            reject({ error: ErrorCodes.REDEEM_ERR, reason: 'Redeem error occured in host' + (data.reason ? ` (${data.reason}).` : '.'), redeemTxHash: redeemTx.txHash });
+                            reject({ error: ErrorCodes.REDEEM_ERR, reason: data.reason, redeemTxHash: redeemTx.txHash });
                         } else {
                             const info = await EncryptionHelper.decrypt(this.accKeyPair.privateKey, payload);
                             resolve(info.content);


### PR DESCRIPTION
- Now the redeem response returns an object when a REDEEM_ERR occurs.
- It is with format { type: 'REDEEM_ERR', reason: ""}
- Reason can be empty if the error was an exception not thrown by us.