### PR TITLE
Send NFT Page related details to Registry inside txn. Memo

### DIFF
--- a/src/clients/base-evernode-client.js
+++ b/src/clients/base-evernode-client.js
@@ -599,7 +599,7 @@ class BaseEvernodeClient {
                     null,
                     [
                         { type: MemoTypes.DEAD_HOST_PRUNE, format: MemoFormats.HEX, data: memoData.toString('hex') },
-                        { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                        { type: MemoTypes.HOST_REGISTRY_REF, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
                     ]);
             } else
                 throw "Invalid Registration NFT."

--- a/src/clients/base-evernode-client.js
+++ b/src/clients/base-evernode-client.js
@@ -10,6 +10,7 @@ const { EventEmitter } = require('../event-emitter');
 const { UtilHelpers } = require('../util-helpers');
 const { FirestoreHandler } = require('../firestore/firestore-handler');
 const { StateHelpers } = require('../state-helpers');
+const { EvernodeHelpers } = require('../evernode-helpers');
 
 class BaseEvernodeClient {
 
@@ -581,11 +582,29 @@ class BaseEvernodeClient {
         let memoData = Buffer.allocUnsafe(20);
         codec.decodeAccountID(hostAddress).copy(memoData);
 
-        await this.xrplAcc.makePayment(this.registryAddress,
-            XrplConstants.MIN_XRP_AMOUNT,
-            XrplConstants.XRP,
-            null,
-            [{ type: MemoTypes.DEAD_HOST_PRUNE, format: MemoFormats.HEX, data: memoData.toString('hex') }]);
+        // To obtain registration NFT Page Keylet and index.
+        const hostAcc = new XrplAccount(hostAddress, null, { xrplApi: this.xrplApi });
+        const regNFT = (await hostAcc.getNfts()).find(n => n.URI.startsWith(EvernodeConstants.NFT_PREFIX_HEX) && n.Issuer === this.registryAddress);
+        if (regNFT) {
+            // Check whether the token was actually issued from Evernode registry contract.
+            const issuerHex = regNFT.NFTokenID.substr(8, 40);
+            const issuerAddr = codec.encodeAccountID(Buffer.from(issuerHex, 'hex'));
+            if (issuerAddr == this.registryAddress) {
+                console.log(regNFT);
+                const nftPageDataBuf = await EvernodeHelpers.getNFTPageAndLocation(regNFT.NFTokenID, hostAcc, this.xrplApi);
+
+                await this.xrplAcc.makePayment(this.registryAddress,
+                    XrplConstants.MIN_XRP_AMOUNT,
+                    XrplConstants.XRP,
+                    null,
+                    [
+                        { type: MemoTypes.DEAD_HOST_PRUNE, format: MemoFormats.HEX, data: memoData.toString('hex') },
+                        { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                    ]);
+            } else
+                throw "Invalid Registration NFT."
+        } else
+            throw "No Registration NFT was found for the Host account."
 
     }
 }

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -271,7 +271,7 @@ class HostClient extends BaseEvernodeClient {
             null,
             [
                 { type: MemoTypes.HOST_DEREG, format: MemoFormats.HEX, data: regNFT.NFTokenID },
-                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                { type: MemoTypes.HOST_REGISTRY_REF, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
             ],
             options.transactionOptions);
 
@@ -349,7 +349,7 @@ class HostClient extends BaseEvernodeClient {
             null,
             [
                 { type: MemoTypes.HOST_UPDATE_INFO, format: MemoFormats.HEX, data: memoBuf.toString('hex') },
-                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                { type: MemoTypes.HOST_REGISTRY_REF, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
             ],
             options.transactionOptions);
     }
@@ -365,7 +365,7 @@ class HostClient extends BaseEvernodeClient {
             null,
             [
                 { type: MemoTypes.HEARTBEAT, format: "", data: "" },
-                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                { type: MemoTypes.HOST_REGISTRY_REF, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
             ],
             options.transactionOptions);
     }
@@ -461,7 +461,7 @@ class HostClient extends BaseEvernodeClient {
             null,
             [
                 { type: MemoTypes.HOST_REBATE, format: "", data: "" },
-                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                { type: MemoTypes.HOST_REGISTRY_REF, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
             ],
             options.transactionOptions);
     }
@@ -506,7 +506,7 @@ class HostClient extends BaseEvernodeClient {
             null,
             [
                 { type: MemoTypes.HOST_TRANSFER, format: MemoFormats.HEX, data: memoData.toString('hex') },
-                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+                { type: MemoTypes.HOST_REGISTRY_REF, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
             ],
             options.transactionOptions);
 

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -261,11 +261,18 @@ class HostClient extends BaseEvernodeClient {
             throw "Host not registered."
 
         const regNFT = await this.getRegistrationNft();
+
+        // To obtain registration NFT Page Keylet and index.
+        const nftPageDataBuf = await EvernodeHelpers.getNFTPageAndLocation(regNFT.NFTokenID, this.xrplAcc, this.xrplApi);
+
         await this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,
             null,
-            [{ type: MemoTypes.HOST_DEREG, format: MemoFormats.HEX, data: regNFT.NFTokenID }],
+            [
+                { type: MemoTypes.HOST_DEREG, format: MemoFormats.HEX, data: regNFT.NFTokenID },
+                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+            ],
             options.transactionOptions);
 
         console.log('Waiting for the buy offer')
@@ -331,22 +338,35 @@ class HostClient extends BaseEvernodeClient {
             memoBuf.writeUInt8(components[2], HOST_UPDATE_VERSION_MEMO_OFFSET + 2);
         }
 
+        // To obtain registration NFT Page Keylet and index.
+        if (!tokenID)
+            tokenID = (await this.getRegistrationNft()).NFTokenID;
+        const nftPageDataBuf = await EvernodeHelpers.getNFTPageAndLocation(tokenID, this.xrplAcc, this.xrplApi);
+
         return await this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,
             null,
-            [{ type: MemoTypes.HOST_UPDATE_INFO, format: MemoFormats.HEX, data: memoBuf.toString('hex') }],
+            [
+                { type: MemoTypes.HOST_UPDATE_INFO, format: MemoFormats.HEX, data: memoBuf.toString('hex') },
+                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+            ],
             options.transactionOptions);
     }
 
-    async heartbeat(nfTokenId, options = {}) {
-        const nftMemoData = await EvernodeHelpers.getNFTPageAndLocation(nfTokenId, this.xrplAcc, this.xrplApi);
+    async heartbeat(options = {}) {
+        // To obtain registration NFT Page Keylet and index.
+        const regNFT = await this.getRegistrationNft();
+        const nftPageDataBuf = await EvernodeHelpers.getNFTPageAndLocation(regNFT.NFTokenID, this.xrplAcc, this.xrplApi);
+
         return this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,
             null,
-            [{ type: MemoTypes.HEARTBEAT, format: "", data: "" },
-            { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftMemoData.toString('hex')}],
+            [
+                { type: MemoTypes.HEARTBEAT, format: "", data: "" },
+                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+            ],
             options.transactionOptions);
     }
 
@@ -430,11 +450,19 @@ class HostClient extends BaseEvernodeClient {
     }
 
     async requestRebate(options = {}) {
+
+        // To obtain registration NFT Page Keylet and index.
+        const regNFT = await this.getRegistrationNft();
+        const nftPageDataBuf = await EvernodeHelpers.getNFTPageAndLocation(regNFT.NFTokenID, this.xrplAcc, this.xrplApi);
+
         return this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,
             null,
-            [{ type: MemoTypes.HOST_REBATE, format: "", data: "" }],
+            [
+                { type: MemoTypes.HOST_REBATE, format: "", data: "" },
+                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+            ],
             options.transactionOptions);
     }
 
@@ -465,16 +493,21 @@ class HostClient extends BaseEvernodeClient {
             }
         }
 
-        const regNFT = (await this.xrplAcc.getNfts()).find(n => n.URI.startsWith(EvernodeConstants.NFT_PREFIX_HEX) && n.Issuer === this.registryAddress);
-
         let memoData = Buffer.allocUnsafe(20);
         codec.decodeAccountID(transfereeAddress).copy(memoData);
+
+        // To obtain registration NFT Page Keylet and index.
+        const regNFT = await this.getRegistrationNft();
+        const nftPageDataBuf = await EvernodeHelpers.getNFTPageAndLocation(regNFT.NFTokenID, this.xrplAcc, this.xrplApi);
 
         await this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,
             null,
-            [{ type: MemoTypes.HOST_TRANSFER, format: MemoFormats.HEX, data: memoData.toString('hex') }],
+            [
+                { type: MemoTypes.HOST_TRANSFER, format: MemoFormats.HEX, data: memoData.toString('hex') },
+                { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftPageDataBuf.toString('hex') }
+            ],
             options.transactionOptions);
 
         let offer = null;

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -135,8 +135,8 @@ class HostClient extends BaseEvernodeClient {
             throw "description should consist of 0-26 ascii characters except ';'";
 
         else if (!emailAddress || !(/[a-z0-9]+@[a-z]+.[a-z]{2,3}/.test(emailAddress)) || (emailAddress.length > 40))
-            throw "Email address should be valid and can not have more than 40 characters.";    
-        
+            throw "Email address should be valid and can not have more than 40 characters.";
+
         if (await this.isRegistered())
             throw "Host already registered.";
 
@@ -278,12 +278,14 @@ class HostClient extends BaseEvernodeClient {
             options.transactionOptions);
     }
 
-    async heartbeat(options = {}) {
+    async heartbeat(nfTokenId, options = {}) {
+        const nftMemoData = await EvernodeHelpers.getNFTPageAndLocation(nfTokenId, this.xrplAcc, this.xrplApi);
         return this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,
             null,
-            [{ type: MemoTypes.HEARTBEAT, format: "", data: "" }],
+            [{ type: MemoTypes.HEARTBEAT, format: "", data: "" },
+            { type: MemoTypes.NFTPAGE_KEYLET_N_IDX, format: MemoFormats.HEX, data: nftMemoData.toString('hex')}],
             options.transactionOptions);
     }
 

--- a/src/evernode-common.js
+++ b/src/evernode-common.js
@@ -25,7 +25,8 @@ const MemoTypes = {
     REFUND: 'evnRefund',
     REFUND_REF: 'evnRefundRef',
     DEAD_HOST_PRUNE: 'evnDeadHostPrune',
-    HOST_REBATE: 'evnHostRebate'
+    HOST_REBATE: 'evnHostRebate',
+    NFTPAGE_KEYLET_N_IDX: 'NFTPageKeyltNIdx'
 }
 
 const MemoFormats = {

--- a/src/evernode-common.js
+++ b/src/evernode-common.js
@@ -26,7 +26,7 @@ const MemoTypes = {
     REFUND_REF: 'evnRefundRef',
     DEAD_HOST_PRUNE: 'evnDeadHostPrune',
     HOST_REBATE: 'evnHostRebate',
-    NFTPAGE_KEYLET_N_IDX: 'NFTPageKeyltNIdx'
+    HOST_REGISTRY_REF: 'evnHostRegistryRef'
 }
 
 const MemoFormats = {

--- a/src/evernode-helpers.js
+++ b/src/evernode-helpers.js
@@ -1,4 +1,5 @@
 const { EvernodeConstants } = require('./evernode-common');
+const NFT_PAGE_LEDGER_ENTRY_TYPE_HEX = '0050';
 
 class EvernodeHelpers {
     static async getLeaseOffers(xrplAcc) {
@@ -6,6 +7,36 @@ class EvernodeHelpers {
         const hostTokenIDs = hostNfts.map(nft => nft.NFTokenID);
         const nftOffers = (await xrplAcc.getNftOffers())?.filter(offer => (offer.Flags == 1 && hostTokenIDs.includes(offer.NFTokenID))); // Filter only sell offers
         return nftOffers;
+    }
+
+    static async getNFTPageAndLocation(nfTokenId, xrplAcc, xrplApi, buffer = true) {
+
+        const nftPageApprxKeylet = await xrplAcc.generateKeylet('nftPage', { nfTokenId: nfTokenId });
+        const nftPageMaxKeylet = await xrplAcc.generateKeylet('nftPageMax');
+        // Index is the last 32 bytes of the Keylet (Last 64 HEX characters).
+        let page = await xrplApi.getLedgerEntry(nftPageMaxKeylet.substring(4, 68));
+        while (page?.PreviousPageMin) {
+            // Compare the low 96 bits. (Last 24 HEX characters).
+            if (Number('0x' + page.index.substring(40, 64)) >= Number('0x' + nftPageApprxKeylet.substring(40, 64))) {
+                // Check the existence of the NFToken
+                let token = page.NFTokens.find(n => n.NFToken.NFTokenID == nfTokenId);
+                if (!token) {
+                    page = await xrplApi.getLedgerEntry(page.PreviousPageMin);
+                }
+                else
+                    break;
+            }
+        }
+
+        const nftPageInfo = page.NFTokens.map((n, loc) => { return { NFTPage: NFT_PAGE_LEDGER_ENTRY_TYPE_HEX + page.index, NFTokenID: n.NFToken.NFTokenID, location: loc } }).find(n => n.NFTokenID == nfTokenId);
+        if (buffer) {
+            let locBuf = Buffer.allocUnsafe(2);
+            locBuf.writeUInt16BE(nftPageInfo.location);
+            // <NFT_PAGE_KEYLET(34 bytes)><LOCATION(2 bytes)>
+            return Buffer.concat([Buffer.from(nftPageInfo.NFTPage, "hex"), locBuf]);
+        }
+
+        return nftPageInfo;
     }
 }
 

--- a/src/xrpl-account.js
+++ b/src/xrpl-account.js
@@ -25,7 +25,7 @@ class XrplAccount {
         this.secret = secret;
         if (this.secret) {
             this.wallet = xrpl.Wallet.fromSeed(this.secret);
-            this.address= this.wallet.classicAddress;
+            this.address = this.wallet.classicAddress;
         }
 
         this.#txStreamHandler = (eventName, tx, error) => {
@@ -346,6 +346,29 @@ class XrplAccount {
         };
 
         return this.#submitAndVerifyTransaction(owner ? { ...tx, Owner: owner } : tx, options);
+    }
+
+    generateKeylet(type, data = {}) {
+        switch (type) {
+            case 'nftPage': {
+                const accIdHex = (codec.decodeAccountID(this.address)).toString('hex').toUpperCase();
+                const tokenPortion = data?.nfTokenId.substr(40, 64);
+                return '0050' + accIdHex + tokenPortion;
+            }
+
+            case 'nftPageMax': {
+                const accIdHex = (codec.decodeAccountID(this.address)).toString('hex').toUpperCase();
+                return '0050' + accIdHex + 'F'.repeat(24);
+            }
+
+            case 'nftPageMin': {
+                const accIdHex = (codec.decodeAccountID(this.address)).toString('hex').toUpperCase();
+                return '0050' + accIdHex + '0'.repeat(24);
+            }
+
+            default:
+                return null;
+        }
     }
 
     async subscribe() {


### PR DESCRIPTION
The NFT page Keylet and the index of the NFT inside that NFT Page are sent to the Registry (inside a different memo)
- In order to reduce the complex computations inside the Hook

