### PR TITLE
Skip reg token ownership check for transferred host prune

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "evernode-js-client",
-    "version": "0.6.9",
+    "version": "0.6.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "evernode-js-client",
-            "version": "0.6.9",
+            "version": "0.6.10",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     ],
     "homepage": "https://github.com/HotPocketDev/evernode-js-client",
     "license": "MIT",
-    "version": "0.6.9",
+    "version": "0.6.10",
     "scripts": {
         "lint": "./node_modules/.bin/eslint src/**/*.js",
         "build:scripts": "ncc build scripts/postinstall.js --minify -o dist/postinstall.js",


### PR DESCRIPTION
- Allow transferred hosts to be pruned
- Skip the reg token ownership if the host is transferred and not reinstalled