### PR TITLE
increase the default timeout

### DIFF
--- a/src/clients/tenant-client.js
+++ b/src/clients/tenant-client.js
@@ -8,7 +8,7 @@ const { EvernodeHelpers } = require('../evernode-helpers');
 const { TransactionHelper } = require('../transaction-helper');
 const { XrplConstants } = require('../xrpl-common');
 
-const DEFAULT_WAIT_TIMEOUT = 600000;
+const DEFAULT_WAIT_TIMEOUT = 3600000;
 
 /**
  * Following tenant-specific events can be subscribed from Evernode client instances.

--- a/src/clients/tenant-client.js
+++ b/src/clients/tenant-client.js
@@ -8,7 +8,7 @@ const { EvernodeHelpers } = require('../evernode-helpers');
 const { TransactionHelper } = require('../transaction-helper');
 const { XrplConstants } = require('../xrpl-common');
 
-const DEFAULT_WAIT_TIMEOUT = 300000;
+const DEFAULT_WAIT_TIMEOUT = 600000;
 
 /**
  * Following tenant-specific events can be subscribed from Evernode client instances.


### PR DESCRIPTION
increase the default timeout as this has been found to be insufficient from evdevkit via acquireLease as no parameter to override is provided here https://github.com/EvernodeXRPL/ev-devkit/blob/5dac6d121c4739835c4cde2a041565175e1c060d/lib/evernode-manager.js#L118 to increase the DEFAULT_WAIT_TIMEOUT to full moment.

with custom docker images they seem to take longer to deploy and the time out is insufficient.
<img width="759" alt="Screenshot 2025-02-23 at 2 39 37 PM" src="https://github.com/user-attachments/assets/d916726c-0e86-48b8-98d5-594cacd4ad43" />
