### PR TITLE
Update host-client.js for better handling of missing messageKey

### DIFF
--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -1120,12 +1120,11 @@ class HostClient extends BaseEvernodeClient {
                 throw "Tenant encryption key not valid.";
         } else {
             encKey = await tenantAcc.getMessageKey();
+            if (!encKey) { data = Buffer.concat([Buffer.from([0x00]), Buffer.from(JSON.stringify({ "instanceInfo": "data omitted as no messagekey on account"}))]).toString('base64'); }
         }
 
-        if (doEncrypt) {
+        if (doEncrypt && encKey) {
             if (!encKey)
-                throw "Tenant encryption key not set.";
-            const encrypted = await EncryptionHelper.encrypt(encKey, instanceInfo);
             // Override encrypted prefix flag and the data.
             data = Buffer.concat([Buffer.from([0x01]), Buffer.from(encrypted, 'base64')]).toString('base64');
         }

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -1117,15 +1117,15 @@ class HostClient extends BaseEvernodeClient {
             } else if (options.messageKey === 'none') {
                 doEncrypt = false;
             } else
-                throw "Tenant encryption key not valid.";
+                throw "Tenant encryption key not present or valid.";
         } else {
             encKey = await tenantAcc.getMessageKey();
             if (!encKey) { data = Buffer.concat([Buffer.from([0x00]), Buffer.from(JSON.stringify({ "instanceInfo": "data omitted as no messagekey on account"}))]).toString('base64'); }
         }
 
         if (doEncrypt && encKey) {
-            if (!encKey)
             // Override encrypted prefix flag and the data.
+            const encrypted = await EncryptionHelper.encrypt(encKey, instanceInfo);
             data = Buffer.concat([Buffer.from([0x01]), Buffer.from(encrypted, 'base64')]).toString('base64');
         }
 


### PR DESCRIPTION
improved missing message key handling on tenants account,
so it doesn't throw fault and stop code when it isn't present, (which produces orphaned/ghost instance)
this PR will make it continue with the instance data omitted, with a error message in its place instead.

we could as an alternative, default to unencrypted ? 
its only used to encrypt the instance info on acquire success currently. so i feel omitting info is a safer method.
as could always implement the already in place method of having `options.messageKey = 'none'` within sashi agent if needed ?

this only occurs when using a different method of signing acquire lease type functions, (as they are not initialised )
which is where I found the fault, when tenants use Xaman to acquire a lease and their accounts are not set with message key.